### PR TITLE
Fix for math-comp 1.9

### DIFF
--- a/src/ssrZ.v
+++ b/src/ssrZ.v
@@ -371,7 +371,8 @@ Qed.
 Lemma z2n_natmul (z : Z) n :
   (0 <= z)%R -> Z.to_nat (z *+ n) = (Z.to_nat z * n)%nat.
 Proof.
-move=> ge0_z; elim: n => // n ih; rewrite mulrS.
+move=> ge0_z; elim: n; first by rewrite muln0.
+move=> n ih; rewrite mulrS.
 by rewrite z2nD ?mulrn_wge0 // ih mulnS.
 Qed.
 


### PR DESCRIPTION
Currently, build fails with the following error:

> COQC src/ssrZ.v
> File "./src/ssrZ.v", line 374, characters 14-32:
> Error:
> Ltac call to "elim (ssrarg) (ssrclauses)" failed.
> No assumption in (Z.to_nat (z *+ 0) = (Z.to_nat z * 0)%N)