### PR TITLE
Rename the logical path from CoqWord to mathcomp.word

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -1,5 +1,5 @@
 (coq.theory
- (name CoqWord)
+ (name mathcomp.word)
  (package coq-mathcomp-word)
  (flags -w -ambiguous-paths
         -w -notation-overridden


### PR DESCRIPTION
Fix #11