### PR TITLE
version: "dev" in opam file

### DIFF
--- a/coq-mathcomp-word.opam
+++ b/coq-mathcomp-word.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "dev"
 maintainer: "pierre-yves@strub.nu"
 homepage: "https://github.com/jasmin-lang/coqword"
 bug-reports: "https://github.com/jasmin-lang/coqword/issues"


### PR DESCRIPTION
If no version is specified, opam's behavior is sometimes puzzling.

In particular, we wanted to write `"coq-mathcomp-word" {>= "2.0"}` in Jasmin's opam file, and it broke the CI, because opam thinks that no version means "1.1" and `1.1 < 2.0`.